### PR TITLE
Add Turkish stemmer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DESTDIR?= /usr
 
 STEMMERS?= danish dutch english finnish french german hungarian \
   italian norwegian porter portuguese romanian russian \
-  spanish swedish
+  spanish swedish turkish
 
 CFLAGS+= \
   -DSQLITE_ENABLE_FTS4 \

--- a/fts3_unicodesn.c
+++ b/fts3_unicodesn.c
@@ -353,6 +353,14 @@ else if ( nIn==7 &&  memcmp("swedish", zIn, 7)==0 ) {
    p->stemmer.stem = swedish_UTF_8_stem;
 }
 #endif
+#ifdef WITH_STEMMER_turkish
+else if ( nIn==7 &&  memcmp("turkish", zIn, 7)==0 ) {
+#include "libstemmer_c/src_c/stem_UTF_8_turkish.h"
+   p->stemmer.create = turkish_UTF_8_create_env;
+   p->stemmer.close = turkish_UTF_8_close_env;
+   p->stemmer.stem = turkish_UTF_8_stem;
+}
+#endif
   else {
       rc  = SQLITE_ERROR;
   }


### PR DESCRIPTION
It looks like the list of stemmers neglected to include the Turkish algorithm that comes with Snowball.  This patch fixes it so `turkish` is available as a stemmer in unicodesn.
