### PR TITLE
Added support for building the tokenizer directly into an app

### DIFF
--- a/fts3_unicode2.c
+++ b/fts3_unicode2.c
@@ -19,6 +19,7 @@
 #if defined(SQLITE_ENABLE_FTS3) || defined(SQLITE_ENABLE_FTS4)
 
 #include <assert.h>
+#include "fts3Int.h"
 
 /*
 ** Return true if the argument corresponds to a unicode codepoint

--- a/fts3_unicodesn.c
+++ b/fts3_unicodesn.c
@@ -389,7 +389,7 @@ static int unicodeCreate(
 
   for(i=0; rc==SQLITE_OK && i<nArg; i++){
     const char *z = azArg[i];
-    int n = strlen(z);
+    int n = (int)strlen(z);
 
     if( n==19 && memcmp("remove_diacritics=1", z, 19)==0 ){
       pNew->bRemoveDiacritic = 1;
@@ -540,10 +540,10 @@ static int unicodeNext(
   );
 
   if ( pCsr->pStemmer!=NULL ) {
-     SN_set_current(pCsr->pStemmer, zOut - pCsr->zToken, (unsigned char *)pCsr->zToken);
+     SN_set_current(pCsr->pStemmer, (int)(zOut - pCsr->zToken), (unsigned char *)pCsr->zToken);
      if ( p->stemmer.stem(pCsr->pStemmer)<0 ) {
 	*paToken = pCsr->zToken;
-	*pnToken = zOut - pCsr->zToken;
+	*pnToken = (int)(zOut - pCsr->zToken);
      }else {
 	pCsr->pStemmer->p[pCsr->pStemmer->l] = '\0';
 	*paToken = (char *)pCsr->pStemmer->p;
@@ -551,13 +551,13 @@ static int unicodeNext(
      }
   }else {
      *paToken = pCsr->zToken;
-     *pnToken = zOut - pCsr->zToken;
+     *pnToken = (int)(zOut - pCsr->zToken);
   }
 
   /* Set the output variables and return. */
-  pCsr->iOff = (z - pCsr->aInput);
-  *piStart = (zStart - pCsr->aInput);
-  *piEnd = (zEnd - pCsr->aInput);
+  pCsr->iOff = (int)(z - pCsr->aInput);
+  *piStart = (int)(zStart - pCsr->aInput);
+  *piEnd = (int)(zEnd - pCsr->aInput);
   *piPos = pCsr->iToken++;
   return SQLITE_OK;
 }

--- a/fts3_unicodesn.c
+++ b/fts3_unicodesn.c
@@ -411,7 +411,7 @@ static int unicodeNext(
 ){
   unicode_cursor *pCsr = (unicode_cursor *)pC;
   unicode_tokenizer *p = ((unicode_tokenizer *)pCsr->base.pTokenizer);
-  int iCode;
+  int iCode = 0;
   char *zOut;
   const unsigned char *z = &pCsr->aInput[pCsr->iOff];
   const unsigned char *zStart = z;

--- a/fts3_unicodesn.h
+++ b/fts3_unicodesn.h
@@ -5,7 +5,11 @@
 
 #define TOKENIZER_NAME	"unicodesn"
 
+#ifdef _MSC_VER
+#define UNICODE0_DLL_EXPORTED __declspec(dllexport)
+#else
 #define UNICODE0_DLL_EXPORTED __attribute__((__visibility__("default")))
+#endif
 
 struct sqlite3_api_routines;
 

--- a/libstemmer_c/libstemmer/libstemmer_utf8.c
+++ b/libstemmer_c/libstemmer/libstemmer_utf8.c
@@ -67,9 +67,11 @@ void
 sb_stemmer_delete(struct sb_stemmer * stemmer)
 {
     if (stemmer == 0) return;
-    if (stemmer->close == 0) return;
-    stemmer->close(stemmer->env);
-    stemmer->close = 0;
+    if (stemmer->close != NULL)
+    {
+        stemmer->close(stemmer->env);
+        stemmer->close = NULL;
+    }
     free(stemmer);
 }
 

--- a/libstemmer_c/runtime/api_sq3.c
+++ b/libstemmer_c/runtime/api_sq3.c
@@ -5,7 +5,7 @@
 #include "header.h"
 
 static void *local_calloc(size_t nmemb, size_t size) {
-   void *p = sqlite3_malloc(nmemb*size);
+   void *p = sqlite3_malloc((int)(nmemb*size));
    if (p == NULL)
       return NULL;
    return memset(p, 0, nmemb*size);

--- a/sqlite3_unicodesn_tokenizer.c
+++ b/sqlite3_unicodesn_tokenizer.c
@@ -1,0 +1,46 @@
+/*
+** 2013 September 22
+**
+** The author disclaims copyright to this source code.  In place of
+** a legal notice, here is a blessing:
+**
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+**
+******************************************************************************
+**
+*/
+#include <sqlite3.h>
+
+#include "fts3_unicodesn.h"
+#include "sqlite3_unicodesn_tokenizer.h"
+
+/*
+** Register the tokenizer with FTS3 or FTS4. For use when compiling the tokenizer directly into
+** an application, instead of as a separate shared library.
+*/
+int register_unicodesn_tokenizer(
+      sqlite3 *db          /* The database connection */
+)
+{
+  const sqlite3_tokenizer_module *tokenizer;
+  int rc;
+  sqlite3_stmt *pStmt;
+  const char *zSql = "SELECT fts3_tokenizer(?, ?)";
+
+  sqlite3Fts3UnicodeSnTokenizer(&tokenizer);
+
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
+    return rc;
+  }
+
+  sqlite3_bind_text(pStmt, 1, TOKENIZER_NAME, -1, SQLITE_STATIC);
+  sqlite3_bind_blob(pStmt, 2, &tokenizer, sizeof(tokenizer), SQLITE_TRANSIENT);
+  rc = sqlite3_step(pStmt);
+  if( rc!=SQLITE_OK && rc < SQLITE_ROW ){
+      return rc;
+  }
+  return sqlite3_finalize(pStmt);
+}

--- a/sqlite3_unicodesn_tokenizer.h
+++ b/sqlite3_unicodesn_tokenizer.h
@@ -1,0 +1,12 @@
+#ifndef _UNICODESN_TOKENIZER_H_
+#define _UNICODESN_TOKENIZER_H_
+
+/*
+ ** Registers the Unicode Snowball tokenizer as "unicodesn", for use with SQLite's FTS3 or FTS4.
+ ** This is for use when compiling the tokenizer directly into an application, instead of as a
+ ** separate shared library. Example of usage:
+ **   CREATE VIRTUAL TABLE fts USING fts3(text, tokenize=unicodesn "stemmer=russian");
+ */
+int register_unicodesn_tokenizer(sqlite3 *db);
+
+#endif /* _UNICODESN_TOKENIZER_H_ */


### PR DESCRIPTION
Implemented register_unicodesn_tokenizer() function for directly
registering the tokenizer with a sqlite3*. This is useful on iOS where
applications have to be statically linked and can't use shared libs.