### PR TITLE
fix LGTM warnings "insert header guard"

### DIFF
--- a/libstemmer_c/runtime/api.h
+++ b/libstemmer_c/runtime/api.h
@@ -1,3 +1,5 @@
+#ifndef API_H
+#define API_H
 
 typedef unsigned char symbol;
 
@@ -24,3 +26,4 @@ extern void SN_close_env(struct SN_env * z, int S_size);
 
 extern int SN_set_current(struct SN_env * z, int size, const symbol * s);
 
+#endif //API_H

--- a/libstemmer_c/runtime/header.h
+++ b/libstemmer_c/runtime/header.h
@@ -1,3 +1,5 @@
+#ifndef HEADER_H
+#define HEADER_H
 
 #include <limits.h>
 
@@ -56,3 +58,4 @@ extern symbol * assign_to(struct SN_env * z, symbol * p);
 
 extern void debug(struct SN_env * z, int number, int line_count);
 
+#endif //HEADER_H


### PR DESCRIPTION
It was found for working on Geary project that uses the code from this repo internally. Source: https://gitlab.gnome.org/GNOME/geary/merge_requests/176